### PR TITLE
Fix: add install requires for pip installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-amqp==2.2.2
-billiard==3.5.0.3
-celery==4.1.0
-kombu==4.1.0
-pytz==2017.3
-vine==1.1.4
+celery>=4, <5

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,14 @@ setup(
 
     keywords='Messages',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=[],
+    install_requires=[
+        'amqp==2.2.2',
+        'billiard==3.5.0.3',
+        'celery==4.1.0',
+        'kombu==4.1.0',
+        'pytz==2017.3',
+        'vine==1.1.4'
+    ],
     extras_require={},
     package_data={},
     data_files=[],

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name='notifier',
 
@@ -32,14 +35,7 @@ setup(
 
     keywords='Messages',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=[
-        'amqp==2.2.2',
-        'billiard==3.5.0.3',
-        'celery==4.1.0',
-        'kombu==4.1.0',
-        'pytz==2017.3',
-        'vine==1.1.4'
-    ],
+    install_requires=requirements,
     extras_require={},
     package_data={},
     data_files=[],


### PR DESCRIPTION
Include the requirements packages in the setup file in order to be installed in the notifier pip installation.

These requirements must be updated any time a new requirement package be added to the project.