### PR TITLE
Add entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Micro can be configurated through CLI, environment variables, config file and/or
 These arguments are the highest priority for Micro. So, these overwrite any other parameters set by any other method. The CLI arguments that can be used are:
 
 ```
-$ python -m micro -h
+$ micro -h
 usage: __main__.py [-h] [-b BROKER_URL] [-q QUEUE_NAME] [-H HOSTNAME]
                    [-w NUM_WORKERS] [-l LOG_FROM] [-lp LOG_PATH]
                    [-pp PID_PATH] [--default-params]
@@ -131,13 +131,13 @@ Config file example:
 ```
 
 A config file skeleton can be created using the following command:
-`$ python -m micro --default-params > config.json`
+`$ micro --default-params > config.json`
 
 ### Default values
 The default values are:
 
 ```
-$ python -m micro --default-params
+$ micro --default-params
 {
     "broker_url": "",
     "queue_name": "micro_queue",

--- a/micro/__main__.py
+++ b/micro/__main__.py
@@ -1,5 +1,10 @@
 from .core.microapp import MicroApp
 
-if __name__ == "__main__":
+
+def main():
     app = MicroApp()
     app.start_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     extras_require={},
     package_data={},
     data_files=[],
-    entry_points={},
+    entry_points={'console_scripts': ['micro = micro.__main__:main']}
 )


### PR DESCRIPTION
With this update, `micro` can be executed by:
`python -m micro`
`micro`

For example:
```
$ micro -h
usage: micro [-h] [-b BROKER_URL] [-q QUEUE_NAME] [-H HOSTNAME]
             [-w NUM_WORKERS] [-l LOG_FROM] [-lp LOG_PATH] [-pp PID_PATH]
             [--default-params]

optional arguments:
  -h, --help            show this help message and exit
  -b BROKER_URL, --broker-url BROKER_URL
                        Set the broker url
  -q QUEUE_NAME, --queue-name QUEUE_NAME
                        Set the Celery queue name
  -H HOSTNAME, --hostname HOSTNAME
                        Set the hostname for the workers
  -w NUM_WORKERS, --num-workers NUM_WORKERS
                        Set the Celery worker number
  -l LOG_FROM, --log-from LOG_FROM
                        Set the logger level
  -lp LOG_PATH, --log-path LOG_PATH
                        Set the log file path
  -pp PID_PATH, --pid-path PID_PATH
                        Set the pid file path
  --default-params      Show default parameters
```