### PR TITLE
New Feature: Logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .eggs/*
 .coverage
+tests/micro.log

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These arguments are the highest priority for Micro. So, these overwrite any othe
 ```
 $ micro -h
 usage: micro [-h] [-b BROKER_URL] [-q QUEUE_NAME] [-H HOSTNAME]
-             [-w NUM_WORKERS] [-l LOG_FROM] [-lp LOG_PATH] [-pp PID_PATH]
+             [-w NUM_WORKERS] [-lp LOG_PATH] [-pp PID_PATH]
              [--default-params]
 
 optional arguments:
@@ -87,8 +87,6 @@ optional arguments:
                         Set the hostname for the workers
   -w NUM_WORKERS, --num-workers NUM_WORKERS
                         Set the Celery worker number
-  -l LOG_FROM, --log-from LOG_FROM
-                        Set the logger level
   -lp LOG_PATH, --log-path LOG_PATH
                         Set the log file path
   -pp PID_PATH, --pid-path PID_PATH
@@ -100,18 +98,19 @@ optional arguments:
 The next priority in parameters for Micro are environment variables. The list of environment variables used are:
 
 ```
-MICRO_CONFIG      # config file location: /path/to/config/config.json
-MICRO_PLUGIN_PATH # path to plugin folder: /path/to/plugin/folder
-MICRO_BROKER_URL  # broker url: ampq://user:pass@host:port//
-MICRO_QUEUE_NAME  # queue name used
-MICRO_HOSTNAME    # workers hostname
-MICRO_NUM_WORKERS # number of workers to create (integer number)
-MICRO_LOG_FROM    # minimun log level to write: DEBUG, INFO, WARNING, ERROR, CRITICAL or FATAL
-MICRO_LOG_PATH    # path to log folder: /path/to/log/folder
-MICRO_PID_PATH    # path to pid folder: /path/to/pid/folder
+MICRO_CONFIG             # config file location: /path/to/config/config.json
+MICRO_PLUGIN_PATH        # path to plugin folder: /path/to/plugin/folder
+MICRO_LOG_PATH           # path to log folder: /path/to/plugin/folder
+MICRO_LOG_FROM           # minimun log level to write: DEBUG, INFO, WARNING, ERROR, CRITICAL or FATAL
+MICRO_BROKER_URL         # broker url: ampq://user:pass@host:port//
+MICRO_QUEUE_NAME         # queue name used
+MICRO_HOSTNAME           # workers hostname
+MICRO_NUM_WORKERS        # number of workers to create (integer number)
+MICRO_CELERY_LOG_PATH    # path to Celery log folder: /path/to/celery/log/folder
+MICRO_CELERY_PID_PATH    # path to Celery pid folder: /path/to/celery/pid/folder
 ```
 
-**IMPORTANT:** `MICRO_CONFIG` and `MICRO_PLUGIN_PATH` variables provide the only way to set config file and plugin folder paths.
+**IMPORTANT:** `MICRO_CONFIG`, `MICRO_PLUGIN_PATH`, `MICRO_LOG_PATH` and `MICRO_LOG_FROM` variables provide the only way to set config file, the plugin folder path, the logger file path and the logger level.
 
 ### Config file
 The lowest priority is the use of a JSON config file. The path to this config file must be set using `MICRO_CONFIG` environment variable.
@@ -124,7 +123,6 @@ Config file example:
     "queue_name": "",
     "hostname": "",
     "num_workers": ,
-    "log_from": "",
     "log_path": "/path/to/log/folder",
     "pid_path": "/path/to/pid/folder"
 }
@@ -143,7 +141,6 @@ $ micro --default-params
     "queue_name": "micro_queue",
     "hostname": "micro",
     "num_workers": 1,
-    "log_from": "INFO",
     "log_path": "/var/log",
     "pid_path": "/var/run"
 }

--- a/micro/api/endpoints.py
+++ b/micro/api/endpoints.py
@@ -1,5 +1,6 @@
 from ..core.microapp import MicroApp
 from ..plugin.pluginmanager import PluginManager
+from ..core.logger import log
 
 
 app = MicroApp()
@@ -8,21 +9,25 @@ manager = PluginManager()
 
 @app.task(name=app.function_name("plugins"), queue=app.queue())
 def plugins():
+    log.info("Endpoint call: Micro.plugins()")
     return manager.plugins()
 
 
 @app.task(name=app.function_name("info"), queue=app.queue())
 def info(name):
+    log.info("Endpoint call: Micro.info(%s)" % name)
     return manager.info(name)
 
 
 @app.task(name=app.function_name("help"), queue=app.queue())
 def help(name):
+    log.info("Endpoint call: Micro.help(%s)" % name)
     return manager.help(name)
 
 
 @app.task(name=app.function_name("run"), queue=app.queue())
 def run(plugin_name, **kwargs):
+    log.info("Endpoint call: Micro.run(%s, %s)" % (plugin_name, kwargs))
     plg = manager.instance(plugin_name)
     if not plg:
         return "Plugin not found"

--- a/micro/core/cli.py
+++ b/micro/core/cli.py
@@ -26,10 +26,6 @@ class CLI(ArgumentParser):
                           type=int,
                           required=False,
                           help="Set the Celery worker number")
-        self.add_argument("-l",
-                          "--log-from",
-                          required=False,
-                          help="Set the logger level")
         self.add_argument("-lp",
                           "--log-path",
                           required=False,

--- a/micro/core/logger.py
+++ b/micro/core/logger.py
@@ -1,0 +1,25 @@
+import os
+import logging
+
+log_path = os.environ.get("MICRO_LOG_PATH")
+if not log_path:
+    raise RuntimeError("MICRO_LOG_PATH not set")
+
+logging.getLogger("celery").setLevel(logging.INFO)
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+log_file = os.path.join(log_path, "micro.log")
+logger_handler = logging.FileHandler(log_file)
+logger_handler.setLevel(logging.INFO)
+
+logfmt = "[%(asctime)s] %(levelname)s: %(message)s - " + \
+    "%(filename)s, %(funcName)s, %(lineno)s"
+
+logger_formatter = logging.Formatter(fmt=logfmt,
+                                     datefmt="%Y-%m-%d %H:%M:%S")
+
+logger_handler.setFormatter(logger_formatter)
+
+log.addHandler(logger_handler)

--- a/micro/core/logger.py
+++ b/micro/core/logger.py
@@ -2,17 +2,21 @@ import os
 import logging
 
 log_path = os.environ.get("MICRO_LOG_PATH")
+log_from = os.environ.get("MICRO_LOG_FROM")
 if not log_path:
     raise RuntimeError("MICRO_LOG_PATH not set")
+if not log_from:
+    raise RuntimeError("MICRO_LOG_FROM not set")
 
-logging.getLogger("celery").setLevel(logging.INFO)
+log_level = logging.getLevelName(log_from)
+logging.getLogger("celery").setLevel(log_level)
 
 log = logging.getLogger()
-log.setLevel(logging.INFO)
+log.setLevel(log_level)
 
 log_file = os.path.join(log_path, "micro.log")
 logger_handler = logging.FileHandler(log_file)
-logger_handler.setLevel(logging.INFO)
+logger_handler.setLevel(log_level)
 
 logfmt = "[%(asctime)s] %(levelname)s: %(message)s - " + \
     "%(filename)s, %(funcName)s, %(lineno)s"

--- a/micro/core/microapp.py
+++ b/micro/core/microapp.py
@@ -10,7 +10,6 @@ class MicroApp(Celery):
         self.__namespace = "Micro"
         self.__queue = params.queue_name()
         self.__broker_url = params.broker_url()
-        self.__log_from = params.log_from()
         self.__log_path = params.log_path()
         self.__pid_path = params.pid_path()
         self.__hostname = params.hostname()
@@ -35,7 +34,6 @@ class MicroApp(Celery):
                 "-A", "micro.api.endpoints",
                 "-Q", self.__queue,
                 "-b", self.__broker_url,
-                "-l", self.__log_from,
                 "--logfile=" + log_path,
                 "--pidfile=" + pid_path,
                 "multi", "start"]

--- a/micro/core/microapp.py
+++ b/micro/core/microapp.py
@@ -19,6 +19,7 @@ class MicroApp(Celery):
         super().__init__("Micro",
                          broker=self.__broker_url,
                          backend="rpc://")
+        self.conf.update(CELERYD_HIJACK_ROOT_LOGGER=False)
 
     def queue(self):
         return self.__queue
@@ -33,8 +34,8 @@ class MicroApp(Celery):
         args = ["celery",
                 "-A", "micro.api.endpoints",
                 "-Q", self.__queue,
-                "-l", self.__log_from,
                 "-b", self.__broker_url,
+                "-l", self.__log_from,
                 "--logfile=" + log_path,
                 "--pidfile=" + pid_path,
                 "multi", "start"]

--- a/micro/core/params.py
+++ b/micro/core/params.py
@@ -57,9 +57,9 @@ class Params:
                                      "hostname")
 
     def num_workers(self):
-        return self.__priority_param(self.__args.num_workers,
-                                     "MICRO_NUM_WORKERS",
-                                     "num_workers")
+        return int(self.__priority_param(self.__args.num_workers,
+                                         "MICRO_NUM_WORKERS",
+                                         "num_workers"))
 
     def log_path(self):
         return self.__priority_param(self.__args.log_path,

--- a/micro/core/params.py
+++ b/micro/core/params.py
@@ -12,7 +12,6 @@ class Params:
             "queue_name": "micro_queue",
             "hostname": "micro",
             "num_workers": 1,
-            "log_from": "INFO",
             "log_path": "/var/log",
             "pid_path": "/var/run"
         }
@@ -61,11 +60,6 @@ class Params:
         return self.__priority_param(self.__args.num_workers,
                                      "MICRO_NUM_WORKERS",
                                      "num_workers")
-
-    def log_from(self):
-        return self.__priority_param(self.__args.log_from,
-                                     "MICRO_CELERY_LOG_FROM",
-                                     "log_from")
 
     def log_path(self):
         return self.__priority_param(self.__args.log_path,

--- a/micro/core/params.py
+++ b/micro/core/params.py
@@ -64,15 +64,15 @@ class Params:
 
     def log_from(self):
         return self.__priority_param(self.__args.log_from,
-                                     "MICRO_LOG_FROM",
+                                     "MICRO_CELERY_LOG_FROM",
                                      "log_from")
 
     def log_path(self):
         return self.__priority_param(self.__args.log_path,
-                                     "MICRO_LOG_PATH",
+                                     "MICRO_CELERY_LOG_PATH",
                                      "log_path")
 
     def pid_path(self):
         return self.__priority_param(self.__args.pid_path,
-                                     "MICRO_PID_PATH",
+                                     "MICRO_CELERY_PID_PATH",
                                      "pid_path")

--- a/micro/plugin/pluginmanager.py
+++ b/micro/plugin/pluginmanager.py
@@ -1,6 +1,7 @@
 import os
 import importlib.util as imp
 from .pluginbase import PluginBase
+from ..core.logger import log
 
 
 class PluginManager:
@@ -52,23 +53,34 @@ class PluginManager:
         return plg.help_str
 
     def __load(self):
+        log.info("Load plugins from: {}".format(self.__plugin_path))
         self.__plugins.clear()
         self.__load_plugins(self.__plugin_path)
 
     def __load_plugins(self, path):
         for f in os.listdir(path):
             plugin_folder = os.path.join(path, f)
+            log.info("Load plugins, checking: {}".format(plugin_folder))
             if not os.path.isdir(plugin_folder):
+                msg = "File found in the plugins folder: {}. Omitted" \
+                    .format(plugin_folder)
+                log.warning(msg)
                 continue
 
             plg = self.__load_plugin_from_file(plugin_folder)
             if not plg:
+                msg = "Plugin {} is not valid. Omitted" \
+                    .format(plugin_folder)
+                log.warning(msg)
                 continue
 
             if not plg.name:
-                print("Error, no name set, cannot be loaded")
+                msg = "Plugin {} does not has name. Omitted" \
+                    .format(plugin_folder)
+                log.warning(msg)
                 continue
 
+            log.info("Plugin found: {}".format(plg.name))
             self.__plugins[plg.name] = plg
 
     def __load_plugin_from_file(self, path):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
 green>=2, <3
+testfixtures>=5, <6

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -3,12 +3,18 @@ from unittest import TestCase
 
 
 class TestEndpoints(TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                    os.path.pardir))
         self.path = os.path.join(self.parent, "resources", "plugin")
         os.environ["MICRO_PLUGIN_PATH"] = self.path
+        os.environ["MICRO_LOG_PATH"] = self.parent
+        os.environ["MICRO_LOG_FROM"] = "INFO"
+
+    def tearDown(self):
+        del os.environ["MICRO_PLUGIN_PATH"]
+        del os.environ["MICRO_LOG_PATH"]
+        del os.environ["MICRO_LOG_FROM"]
 
     def test_plugins(self):
         from micro.api.endpoints import plugins

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -3,15 +3,13 @@ from micro.core.cli import CLI
 
 
 class TestCLI(TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cli = CLI()
         self.args = self.cli.parse_args([
             "-b", "url://user:pass@1234//",
             "-q", "queue name",
             "-H", "example_hostname",
             "-w", "5",
-            "-l", "WARNING",
             "-lp", "/path/to/the/logs",
             "-pp", "/path/to/the/pids",
             "--default-params"
@@ -22,7 +20,6 @@ class TestCLI(TestCase):
         self.assertEqual(type(self.args.queue_name), str)
         self.assertEqual(type(self.args.hostname), str)
         self.assertEqual(type(self.args.num_workers), int)
-        self.assertEqual(type(self.args.log_from), str)
         self.assertEqual(type(self.args.log_path), str)
         self.assertEqual(type(self.args.pid_path), str)
         self.assertEqual(type(self.args.default_params), bool)
@@ -32,7 +29,6 @@ class TestCLI(TestCase):
         self.assertEqual(self.args.queue_name, "queue name")
         self.assertEqual(self.args.hostname, "example_hostname")
         self.assertEqual(self.args.num_workers, 5)
-        self.assertEqual(self.args.log_from, "WARNING")
         self.assertEqual(self.args.log_path, "/path/to/the/logs")
         self.assertEqual(self.args.pid_path, "/path/to/the/pids")
         self.assertTrue(self.args.default_params)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,25 +1,26 @@
-from os import path
-from os import environ
+import os
 from unittest import TestCase
 from micro.core.config import Config
 
 
 class TestConfig(TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.parent = path.abspath(path.join(path.dirname(__file__),
-                                             path.pardir))
-        self.file = path.join(self.parent, "resources", "test_config.json")
-        environ["MICRO_CONFIG"] = self.file
+    def setUp(self):
+        self.parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                   os.path.pardir))
+        self.file = os.path.join(self.parent, "resources", "test_config.json")
+        os.environ["MICRO_CONFIG"] = self.file
         self.config = Config()
 
+    def tearDown(self):
+        del os.environ["MICRO_CONFIG"]
+
     def test_open(self):
-        environ["MICRO_CONFIG"] = self.parent
+        os.environ["MICRO_CONFIG"] = self.parent
         with self.assertRaises(Exception) as context:
             Config()
         self.assertEqual(type(context.exception), IsADirectoryError)
 
-        environ["MICRO_CONFIG"] = path.join(self.parent, "wrong_name.json")
+        os.environ["MICRO_CONFIG"] = os.path.join(self.parent, "fakeconf.json")
         with self.assertRaises(Exception) as context:
             Config()
         self.assertEqual(type(context.exception), FileNotFoundError)
@@ -32,6 +33,5 @@ class TestConfig(TestCase):
         self.assertEqual(self.config.key("queue_name"), "queue_name")
         self.assertEqual(self.config.key("hostname"), "config_hostname")
         self.assertEqual(self.config.key("num_workers"), 10)
-        self.assertEqual(self.config.key("log_from"), "ERROR")
         self.assertEqual(self.config.key("log_path"), "/path/to/logs")
         self.assertEqual(self.config.key("pid_path"), "/path/to/pids")

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -1,0 +1,18 @@
+import os
+from unittest import TestCase
+
+
+class TestPluginManager(TestCase):
+    def tearDown(self):
+        del os.environ["MICRO_LOG_PATH"]
+
+    def test_contructor(self):
+        with self.assertRaises(Exception) as context:
+            from micro.core.logger import log
+        self.assertEqual(type(context.exception), RuntimeError)
+
+        os.environ["MICRO_LOG_PATH"] = "/"
+
+        with self.assertRaises(Exception) as context:
+            from micro.core.logger import log
+        self.assertEqual(type(context.exception), RuntimeError)

--- a/tests/core/test_microapp.py
+++ b/tests/core/test_microapp.py
@@ -4,19 +4,20 @@ from micro.core.microapp import MicroApp
 
 
 class TestMicroApp(TestCase):
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         path = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                             os.path.pardir))
 
         path = os.path.join(path, "resources", "test_config.json")
         os.environ["MICRO_CONFIG"] = path
 
+    def tearDown(self):
+        del os.environ["MICRO_CONFIG"]
+
     def test_load_args(self):
         expected = ['celery',
                     '-A', 'micro.api.endpoints',
                     '-Q', 'queue_name',
-                    '-l', 'ERROR',
                     '-b', 'test://user:pass@host:port//',
                     '--logfile=/path/to/logs/%N.log',
                     '--pidfile=/path/to/pids/%N.pid',

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -61,6 +61,19 @@ class TestParams(TestCase):
         self.assertEqual(params.pid_path(),
                          params._Params__default["pid_path"])
 
+    def test_all_types(self):
+        try:
+            del os.environ["MICRO_CONFIG"]
+        except:
+            pass
+        params = Params()
+        self.assertEqual(type(params.broker_url()), str)
+        self.assertEqual(type(params.queue_name()), str)
+        self.assertEqual(type(params.hostname()), str)
+        self.assertEqual(type(params.num_workers()), int)
+        self.assertEqual(type(params.log_path()), str)
+        self.assertEqual(type(params.pid_path()), str)
+
     def __set_config_env(self):
         self.parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                    os.path.pardir))

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -43,7 +43,10 @@ class TestParams(TestCase):
         self.assertDictEqual(json.loads(output), params._Params__default)
 
     def test_all_params(self):
-        del os.environ["MICRO_CONFIG"]
+        try:
+            del os.environ["MICRO_CONFIG"]
+        except:
+            pass
         params = Params()
         self.assertEqual(params.broker_url(),
                          params._Params__default["broker_url"])
@@ -53,8 +56,6 @@ class TestParams(TestCase):
                          params._Params__default["hostname"])
         self.assertEqual(params.num_workers(),
                          params._Params__default["num_workers"])
-        self.assertEqual(params.log_from(),
-                         params._Params__default["log_from"])
         self.assertEqual(params.log_path(),
                          params._Params__default["log_path"])
         self.assertEqual(params.pid_path(),

--- a/tests/plugin/test_pluginmanager.py
+++ b/tests/plugin/test_pluginmanager.py
@@ -1,19 +1,22 @@
 import os
-import io
-import sys
 from unittest import TestCase
-from micro.plugin.pluginmanager import PluginManager
+from testfixtures import LogCapture
 
 
 class TestPluginManager(TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        self.parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                   os.path.pardir))
+        os.environ["MICRO_LOG_PATH"] = self.parent
+        os.environ["MICRO_LOG_FROM"] = "INFO"
+
+    def tearDown(self):
+        del os.environ["MICRO_PLUGIN_PATH"]
+        del os.environ["MICRO_LOG_PATH"]
+        del os.environ["MICRO_LOG_FROM"]
 
     def test_contructor(self):
-        try:
-            del os.environ["MICRO_PLUGIN_PATH"]
-        except:
-            pass
+        from micro.plugin.pluginmanager import PluginManager
 
         with self.assertRaises(Exception) as context:
             PluginManager()
@@ -29,17 +32,28 @@ class TestPluginManager(TestCase):
         pm = PluginManager()
         self.assertEqual(type(pm), PluginManager)
 
-    def test_mamasan(self):
-        parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                              os.path.pardir))
-        path = os.path.join(parent, "resources", "error_plugins")
+    def test_error_plugins(self):
+        path = os.path.join(self.parent, "resources", "error_plugins")
         os.environ["MICRO_PLUGIN_PATH"] = path
-        stdout = sys.stdout
-        sys.stdout = io.StringIO()
+        from micro.plugin.pluginmanager import PluginManager
 
-        PluginManager()
-
-        output = sys.stdout.getvalue()
-        sys.stdout = stdout
-        self.assertEqual(output.strip(),
-                         "Error, no name set, cannot be loaded")
+        with LogCapture() as logs:
+            PluginManager()
+        logs.check(
+            ("root",
+             "INFO",
+             "Load plugins from: " + path),
+            ("root",
+             "INFO",
+             "Load plugins, checking: " + path + "/example_noname"),
+            ("root",
+             "WARNING",
+             "Plugin " + path + "/example_noname " +
+             "does not has name. Omitted"),
+            ("root",
+             "INFO",
+             "Load plugins, checking: " + path + "/example_notype"),
+            ("root",
+             "WARNING",
+             "Plugin " + path + "/example_notype " + "is not valid. Omitted")
+        )

--- a/tests/resources/test_config.json
+++ b/tests/resources/test_config.json
@@ -4,7 +4,6 @@
     "queue_name": "queue_name",
     "hostname": "config_hostname",
     "num_workers": 10,
-    "log_from": "ERROR",
     "log_path": "/path/to/logs",
     "pid_path": "/path/to/pids"
 }


### PR DESCRIPTION
**WORK IN PROGRESS !!!**

With this PR has been added a custom logger to the Micro.
* Adds the `logger.py` file with the logger configuration
  * Gets the logger file path from the environment (`MICRO_LOG_PATH`)
  * Gets the logger level from the environment (`MICRO_LOG_FROM`)
* Sets the `CELERYD_HIJACK_ROOT_LOGGER` to `False` to not use the default Celery logger
* Deletes the `-l, --log-from` argument from the CLI class
* Deletes the `log_from` params from the Params class
* Adds logs to:
  * Endpoints
  * Plugin manager
* Fix tests
* Add test for logs

**NOTE**: despite the default Celery logger is no longer used, it is necessary to set the `--logfile` argument to Celery because it creates the logger files anyway.