### PR TITLE
Fix API Rest response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
     - 'python setup.py test'
 
 after_success:
-    - pip install python-coveralls
+    - pip install coveralls
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
     - 'python setup.py test'
 
 after_success:
-    - pip install coveralls
+    - pip install python-coveralls
     - coveralls

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ API Celery example (using micro-dev)
     >>> req.run.delay("Example plugin", name="Micro").wait()
     'Hello Micro!!!'
 
+
+
 API Rest example (using requests)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -61,7 +63,11 @@ Micro plugins
 -------------
 
 Write Micro plugins is very simple all that you need is to create
-a file called ``interface.py`` this file defines the plugin as follow:
+a file called ``interface.py`` and a class which is the plugin itself.
+
+- the ``interface.py`` file defines the plugin metadata
+- the plugin class must inherit from ``micro.plugin.pluginbasePluginBase``
+  and must return Python dictionaries
 
 .. code:: python
 
@@ -74,8 +80,9 @@ a file called ``interface.py`` this file defines the plugin as follow:
             print("This is an example plugin")
 
         # This is the method executed by Micro
+        # Must return a Python dictionary
         def run(self, name):
-            return "Hello " + name + "!!!"
+            return {"msg": "Hello " + name + "!!!"}
 
 
     # This description is required by Micro

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ API Celery example (using micro-dev)
     '[{"name": "Example Plugin", "version": null, "description": "A very simple example plugin"}]'
     >>>
     >>> req.run.delay("Example plugin", name="Micro").wait()
-    'Hello Micro!!!'
+    {"msg": "Hello Micro!!!"}
 
 
 
@@ -57,7 +57,7 @@ API Rest example (using requests)
     >>> headers = {'content-type': 'application/json'}
     >>> response = requests.request("POST", url, data=payload, headers=headers)
     >>> print(response.text)
-    Hello Micro!!!
+    {"msg": "Hello Micro!!!"}
 
 Micro plugins
 -------------

--- a/micro/api/apirest.py
+++ b/micro/api/apirest.py
@@ -1,3 +1,5 @@
+import json
+from flask import jsonify
 from flask import request
 from flask import Blueprint
 from .endpoints import _help
@@ -10,20 +12,26 @@ endpoints = Blueprint("endpoints", __name__)
 
 @endpoints.route("/plugins", methods=["GET"])
 def plugins():
-    return _plugins()
+    return jsonify(_plugins())
 
 
 @endpoints.route("/info/<name>", methods=["GET"])
 def info(name):
-    return _info(name)
+    return jsonify(_info(name))
 
 
 @endpoints.route("/help/<name>", methods=["GET"])
 def help(name):
-    return _help(name)
+    return jsonify(_help(name))
 
 
 @endpoints.route("/run/<name>", methods=["POST"])
 def run(name):
     kwargs = request.get_json()
-    return _run(name, **kwargs)
+    resp = _run(name, **kwargs)
+    try:
+        resp = json.loads(resp)
+    except ValueError:
+        pass
+
+    return jsonify(resp)

--- a/micro/api/apirest.py
+++ b/micro/api/apirest.py
@@ -1,4 +1,3 @@
-import json
 from flask import jsonify
 from flask import request
 from flask import Blueprint
@@ -28,10 +27,4 @@ def help(name):
 @endpoints.route("/run/<name>", methods=["POST"])
 def run(name):
     kwargs = request.get_json()
-    resp = _run(name, **kwargs)
-    try:
-        resp = json.loads(resp)
-    except ValueError:
-        pass
-
-    return jsonify(resp)
+    return jsonify(_run(name, **kwargs))

--- a/micro/api/celery.py
+++ b/micro/api/celery.py
@@ -25,10 +25,4 @@ def help(name):
 
 @app.task(name=app.function_name("run"), queue=app.queue())
 def run(plugin_name, **kwargs):
-    resp = _run(plugin_name, **kwargs)
-    try:
-        resp = json.loads(resp)
-    except ValueError:
-        pass
-
-    return json.dumps(resp)
+    return json.dumps(_run(plugin_name, **kwargs))

--- a/micro/api/celery.py
+++ b/micro/api/celery.py
@@ -1,3 +1,4 @@
+import json
 from .endpoints import _help
 from .endpoints import _info
 from .endpoints import _plugins
@@ -9,19 +10,25 @@ app = CeleryApp()
 
 @app.task(name=app.function_name("plugins"), queue=app.queue())
 def plugins():
-    return _plugins()
+    return json.dumps(_plugins())
 
 
 @app.task(name=app.function_name("info"), queue=app.queue())
 def info(name):
-    return _info(name)
+    return json.dumps(_info(name))
 
 
 @app.task(name=app.function_name("help"), queue=app.queue())
 def help(name):
-    return _help(name)
+    return json.dumps(_help(name))
 
 
 @app.task(name=app.function_name("run"), queue=app.queue())
 def run(plugin_name, **kwargs):
-    return _run(plugin_name, **kwargs)
+    resp = _run(plugin_name, **kwargs)
+    try:
+        resp = json.loads(resp)
+    except ValueError:
+        pass
+
+    return json.dumps(resp)

--- a/micro/api/endpoints.py
+++ b/micro/api/endpoints.py
@@ -25,11 +25,14 @@ def _run(plugin_name, **kwargs):
     log.info("Endpoint call: Micro.run(%s, %s)" % (plugin_name, kwargs))
     plg = manager.instance(plugin_name)
     if not plg:
-        return json.dumps({"error": "plugin not found"})
+        msg = "plugin not found"
+        log.error(msg)
+        return json.dumps({"error": msg})
 
     try:
         result = plg.run(**kwargs)
     except TypeError as e:
+        log.error(str(e))
         return json.dumps({"error": str(e)})
 
     return result

--- a/micro/api/endpoints.py
+++ b/micro/api/endpoints.py
@@ -1,4 +1,3 @@
-import json
 from ..core.logger import Logger
 from ..plugin.pluginmanager import PluginManager
 
@@ -27,12 +26,18 @@ def _run(plugin_name, **kwargs):
     if not plg:
         msg = "plugin not found"
         log.error(msg)
-        return json.dumps({"error": msg})
+        return {"error": msg}
 
     try:
         result = plg.run(**kwargs)
     except TypeError as e:
         log.error(str(e))
-        return json.dumps({"error": str(e)})
+        return {"error": str(e)}
+
+    if not isinstance(result, dict):
+        msg = "Micro plugins must return a Python dictionary"
+        response = "%s, type: %s, value: %s" % (msg, type(result), str(result))
+        log.error(response)
+        return {"error": response}
 
     return result

--- a/micro/plugin/pluginmanager.py
+++ b/micro/plugin/pluginmanager.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import json
 import importlib.util as imp
 from .pluginbase import PluginBase
 from ..core.logger import Logger
@@ -34,15 +33,15 @@ class PluginManager:
             }
             result.append(plugin)
 
-        return json.dumps(result)
+        return result
 
     def info(self, name):
         plg = self.__plugins.get(name)
 
         if not plg:
-            return json.dumps({"error": "plugin not found"})
+            return {"error": "plugin not found"}
 
-        plugin = {
+        return {
             "name": plg.name,
             "version": plg.version,
             "url": plg.url,
@@ -52,21 +51,17 @@ class PluginManager:
             "long_description": plg.long_description
         }
 
-        return json.dumps(plugin)
-
     def help(self, name):
         plg = self.__plugins.get(name)
 
         if not plg:
-            return json.dumps({"error": "plugin not found"})
+            return {"error": "plugin not found"}
 
-        plugin = {
+        return {
             "name": plg.name,
             "version": plg.version,
             "help": plg.plugin_help
         }
-
-        return json.dumps(plugin)
 
     def __load(self):
         self.__log.info("Load plugins from: {}".format(self.__plugin_path))

--- a/tests/api/test_apirest.py
+++ b/tests/api/test_apirest.py
@@ -118,4 +118,5 @@ class TestAPIRestEndpoints(TestCase):
                                    content_type="application/json")
             self.assertEquals(response.status_code, 200)
             self.assertEquals(response.mimetype, "application/json")
-            self.assertEquals(json.loads(response.data), "Hello World!!!")
+            self.assertDictEqual(json.loads(response.data),
+                                 {"msg": "Hello World!!!"})

--- a/tests/api/test_apirest.py
+++ b/tests/api/test_apirest.py
@@ -41,6 +41,7 @@ class TestAPIRestEndpoints(TestCase):
         with self.app.test_client() as client:
             response = client.get("/plugins")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
     def test_info(self):
@@ -48,6 +49,7 @@ class TestAPIRestEndpoints(TestCase):
         with self.app.test_client() as client:
             response = client.get("/info/not-existent-plugin")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
         long_description = "This plugin is a very simple example, " + \
@@ -63,7 +65,9 @@ class TestAPIRestEndpoints(TestCase):
         }
         with self.app.test_client() as client:
             response = client.get("/info/Example%20Plugin")
+            self.assertTrue(True)
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
     def test_help(self):
@@ -71,6 +75,7 @@ class TestAPIRestEndpoints(TestCase):
         with self.app.test_client() as client:
             response = client.get("/help/not-existent-plugin")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
         resp = {
@@ -81,6 +86,7 @@ class TestAPIRestEndpoints(TestCase):
         with self.app.test_client() as client:
             response = client.get("/help/Example%20Plugin")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
     def test_run(self):
@@ -91,6 +97,7 @@ class TestAPIRestEndpoints(TestCase):
                                    data=json.dumps(data),
                                    content_type="application/json")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
         resp = {
@@ -101,6 +108,7 @@ class TestAPIRestEndpoints(TestCase):
                                    data=json.dumps(data),
                                    content_type="application/json")
             self.assertEquals(response.status_code, 200)
+            self.assertEquals(response.mimetype, "application/json")
             self.assertEquals(json.loads(response.data), resp)
 
         data = {"name": "World"}
@@ -109,4 +117,5 @@ class TestAPIRestEndpoints(TestCase):
                                    data=json.dumps(data),
                                    content_type="application/json")
             self.assertEquals(response.status_code, 200)
-            self.assertEquals(response.data.decode("utf-8"), "Hello World!!!")
+            self.assertEquals(response.mimetype, "application/json")
+            self.assertEquals(json.loads(response.data), "Hello World!!!")

--- a/tests/api/test_celery.py
+++ b/tests/api/test_celery.py
@@ -73,7 +73,7 @@ class TestCeleryEndpoints(TestCase):
         from micro.api.celery import run
         self.assertEqual(run.apply(args=("Example Plugin",),
                                    kwargs={"name": "World"}).get(),
-                         json.dumps("Hello World!!!"))
+                         json.dumps({"msg": "Hello World!!!"}))
 
         error = "run() got an unexpected keyword argument \'wrong_arg\'"
         self.assertEqual(run.apply(args=("Example Plugin",),

--- a/tests/api/test_celery.py
+++ b/tests/api/test_celery.py
@@ -73,7 +73,7 @@ class TestCeleryEndpoints(TestCase):
         from micro.api.celery import run
         self.assertEqual(run.apply(args=("Example Plugin",),
                                    kwargs={"name": "World"}).get(),
-                         "Hello World!!!")
+                         json.dumps("Hello World!!!"))
 
         error = "run() got an unexpected keyword argument \'wrong_arg\'"
         self.assertEqual(run.apply(args=("Example Plugin",),

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -1,0 +1,77 @@
+import os
+import shutil
+from unittest import TestCase
+from micro.core.params import Params
+
+
+class TestEndpoints(TestCase):
+    def setUp(self):
+        self.test_folders = [
+            ["MICRO_LOG_FOLDER_PATH", "/tmp/micro_apirest_logs"],
+            ["MICRO_PID_FOLDER_PATH", "/tmp/micro_apirest_pids"]
+        ]
+        for f in self.test_folders:
+            os.environ[f[0]] = f[1]
+            os.makedirs(f[1], exist_ok=True)
+
+    def tearDown(self):
+        try:
+            del os.environ["MICRO_PLUGIN_PATH"],
+            del os.environ["_MICRO_PLUGIN_PATH"],
+        except Exception:
+            pass
+
+        for f in self.test_folders:
+            del os.environ[f[0]]
+            shutil.rmtree(f[1])
+
+    def test_run(self):
+        parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                              os.path.pardir))
+        plugins = os.path.join(parent, "resources", "plugin")
+        os.environ["MICRO_PLUGIN_PATH"] = plugins
+        Params(setall=True).set_params()
+
+        from micro.plugin.pluginmanager import PluginManager
+        from micro.api.endpoints import _run
+        from micro.api import endpoints
+        endpoints.manager = PluginManager()
+
+        resp = _run(plugin_name="wrong plugin")
+        expected = {"error": "plugin not found"}
+        self.assertDictEqual(resp, expected)
+
+        data = {"wrong_arg": "World"}
+        resp = _run(plugin_name="Example Plugin", **data)
+        expected = {
+            "error": "run() got an unexpected keyword argument 'wrong_arg'"
+        }
+        self.assertDictEqual(resp, expected)
+
+        data = {"name": "World"}
+        resp = _run(plugin_name="Example Plugin", **data)
+        expected = {
+            "msg": "Hello World!!!"
+        }
+        self.assertDictEqual(resp, expected)
+
+    def test_run_no_dict(self):
+        parent = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                              os.path.pardir))
+        plugins = os.path.join(parent, "resources", "error_plugins")
+        os.environ["MICRO_PLUGIN_PATH"] = plugins
+        Params(setall=True).set_params()
+
+        from micro.plugin.pluginmanager import PluginManager
+        from micro.api.endpoints import _run
+        from micro.api import endpoints
+        endpoints.manager = PluginManager()
+
+        data = {"name": "World"}
+        resp = _run(plugin_name="Example Plugin No Dict", **data)
+        error_msg = "Micro plugins must return a Python dictionary"
+        msg = "Hello World!!!"
+        expected = {
+            "error": "%s, type: %s, value: %s" % (error_msg, type(msg), msg)
+        }
+        self.assertDictEqual(resp, expected)

--- a/tests/core/test_validate.py
+++ b/tests/core/test_validate.py
@@ -15,6 +15,8 @@ class TestValidate(TestCase):
         SettingTest.validator = Validate.positive_int
         s = SettingTest()
 
+        self.assertIsNone(s.validator(None))
+
         self.assertEqual(s.validator(1), 1)
         self.assertEqual(s.validator(10000000), 10000000)
 

--- a/tests/plugin/test_pluginmanager.py
+++ b/tests/plugin/test_pluginmanager.py
@@ -85,5 +85,12 @@ class TestPluginManager(TestCase):
              "File found in the plugins folder: "
              + path + "/file_to_ommit. "
              "Omitted"),
+            ("Micro",
+             "INFO",
+             "Load plugins, checking: "
+             + path + "/example_nodict"),
+            ("Micro",
+             "INFO",
+             "Plugin found: Example Plugin No Dict"),
             order_matters=False
         )

--- a/tests/resources/error_plugins/example_nodict/interface.py
+++ b/tests/resources/error_plugins/example_nodict/interface.py
@@ -1,0 +1,20 @@
+from micro.plugin.pluginbase import PluginBase
+from micro.plugin.pluginbase import PluginDescription
+
+
+class ExamplePluginNoDict(PluginBase):
+    # This is the method executed by Micro
+    def run(self, name):
+        return "Hello " + name + "!!!"
+
+
+# This description is required by Micro
+plugin = PluginDescription(
+    instance=ExamplePluginNoDict,
+    name="Example Plugin No Dict",
+    author="Jhon Doe",
+    description="A very simple example plugin",
+    long_description="This plugin is a very simple example, "
+                     "for that reason, we don't have a long description",
+    plugin_help="Params: name type string; A name to greet"
+)

--- a/tests/resources/plugin/example/interface.py
+++ b/tests/resources/plugin/example/interface.py
@@ -5,7 +5,7 @@ from micro.plugin.pluginbase import PluginDescription
 class ExamplePlugin(PluginBase):
     # This is the method executed by Micro
     def run(self, name):
-        return "Hello " + name + "!!!"
+        return {"msg": "Hello " + name + "!!!"}
 
 
 # This description is required by Micro


### PR DESCRIPTION
Currently, the Celery and API Rest endpoint's responses are JSON values so the API Rest endpoints have been updated to return the standard `mimetype` values